### PR TITLE
Resolve lint errors and tighten typing

### DIFF
--- a/src/hooks/useGoogleMaps.ts
+++ b/src/hooks/useGoogleMaps.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Loader } from '@googlemaps/js-api-loader';
 
 interface UseGoogleMapsReturn {
@@ -20,11 +20,14 @@ export const useGoogleMaps = (elementId: string, config: MapConfig = {}): UseGoo
   const [map, setMap] = useState<google.maps.Map | null>(null);
   const [geocoder, setGeocoder] = useState<google.maps.Geocoder | null>(null);
 
-  const defaultConfig = {
-    center: { lat: -6.2088, lng: 106.8456 }, // Jakarta, Indonesia (Tuk Tuk country!)
-    zoom: 13,
-    ...config,
-  };
+  const defaultConfig = useMemo(
+    () => ({
+      center: { lat: -6.2088, lng: 106.8456 }, // Jakarta, Indonesia (Tuk Tuk country!)
+      zoom: 13,
+      ...config,
+    }),
+    [config]
+  );
 
   useEffect(() => {
     const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
@@ -73,7 +76,7 @@ export const useGoogleMaps = (elementId: string, config: MapConfig = {}): UseGoo
         console.error('Error loading Google Maps:', error);
         setLoadError('Failed to load Google Maps');
       });
-  }, [elementId, defaultConfig.center.lat, defaultConfig.center.lng, defaultConfig.zoom]);
+  }, [elementId, defaultConfig]);
 
   return { isLoaded, loadError, map, geocoder };
 };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -50,8 +50,8 @@ export type Database = {
           driver_id: string | null;
           pickup_addr: string;
           dropoff_addr: string;
-          pickup_point: any;
-          dropoff_point: any;
+          pickup_point: string;
+          dropoff_point: string;
           status: 'REQUESTED' | 'ASSIGNED' | 'ENROUTE' | 'STARTED' | 'COMPLETED' | 'CANCELLED';
           estimated_fare: number;
           actual_fare: number | null;
@@ -66,8 +66,8 @@ export type Database = {
           rider_id: string;
           pickup_addr: string;
           dropoff_addr: string;
-          pickup_point: any;
-          dropoff_point: any;
+          pickup_point: string;
+          dropoff_point: string;
           estimated_fare: number;
           distance_km?: number | null;
         };
@@ -83,7 +83,7 @@ export type Database = {
         Row: {
           id: string;
           driver_id: string;
-          location: any;
+          location: string;
           heading: number | null;
           speed_kmh: number | null;
           accuracy_meters: number | null;

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -18,6 +18,7 @@ interface RideHistory {
   actual_fare: number | null;
   requested_at: string;
   completed_at: string | null;
+  driver_id: string | null;
   driver?: {
     full_name: string;
   };
@@ -51,6 +52,7 @@ export const History: React.FC = () => {
           actual_fare,
           requested_at,
           completed_at,
+          driver_id,
           driver:profiles!rides_driver_id_fkey(full_name),
           rating:ratings(score, note)
         `)
@@ -275,10 +277,10 @@ export const History: React.FC = () => {
                 fullWidth
                 onClick={() => {
                   const ride = rides.find(r => r.id === showRatingModal);
-                  if (ride?.driver) {
-                    // Get driver ID from the ride - we'll need to fetch it
-                    // For now, we'll just show a message
-                    toast.error('Rating feature requires driver ID');
+                  if (ride?.driver_id) {
+                    submitRating(ride.id, ride.driver_id);
+                  } else {
+                    toast.error('Rating feature requires driver information');
                   }
                 }}
               >

--- a/src/pages/RequestRide.tsx
+++ b/src/pages/RequestRide.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { MapPin, Navigation, ArrowRight } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../hooks/useAuth';
-import { useGoogleMaps, usePlacesAutocomplete, geocodeAddress } from '../hooks/useGoogleMaps';
+import { useGoogleMaps, usePlacesAutocomplete } from '../hooks/useGoogleMaps';
 import { calculateDistance, calculateFare, formatCurrency } from '../lib/utils';
 import { Button } from '../components/Button';
 import { Input } from '../components/Input';
@@ -23,8 +23,8 @@ export const RequestRide: React.FC = () => {
     zoom: 13,
   });
   
-  const { place: pickupPlace, setPlace: setPickupPlace } = usePlacesAutocomplete(pickupRef);
-  const { place: dropoffPlace, setPlace: setDropoffPlace } = usePlacesAutocomplete(dropoffRef);
+  const { place: pickupPlace } = usePlacesAutocomplete(pickupRef);
+  const { place: dropoffPlace } = usePlacesAutocomplete(dropoffRef);
 
   // Calculate fare when both places are selected
   useEffect(() => {

--- a/src/pages/RideTracking.tsx
+++ b/src/pages/RideTracking.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Phone, X, CreditCard, Star, MapPin, Clock } from 'lucide-react';
+import { Phone, X, CreditCard, Star, MapPin } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { useAuth } from '../hooks/useAuth';
 import { useGoogleMaps } from '../hooks/useGoogleMaps';
-import { formatCurrency, maskPhone, formatRelativeTime } from '../lib/utils';
+import { formatCurrency, formatRelativeTime } from '../lib/utils';
 import { Button } from '../components/Button';
 import { StatusChip } from '../components/StatusChip';
 import { LoadingSpinner } from '../components/LoadingSpinner';
@@ -16,8 +16,8 @@ interface Ride {
   driver_id: string | null;
   pickup_addr: string;
   dropoff_addr: string;
-  pickup_point: any;
-  dropoff_point: any;
+  pickup_point: string;
+  dropoff_point: string;
   status: 'REQUESTED' | 'ASSIGNED' | 'ENROUTE' | 'STARTED' | 'COMPLETED' | 'CANCELLED';
   estimated_fare: number;
   actual_fare: number | null;
@@ -30,7 +30,7 @@ interface Ride {
 
 interface DriverLocation {
   driver_id: string;
-  location: any;
+  location: string;
   updated_at: string;
 }
 


### PR DESCRIPTION
## Summary
- stabilize Google Maps hook with `useMemo` and proper effect deps
- type Supabase geometry fields as strings
- wire up ride rating flow and remove unused imports

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c052e976448329887b903a3d8eb3b5