### PR TITLE
Fix lint errors and improve type safety

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,9 @@
 import { supabase } from './supabase';
-import { AppError, NetworkError, handleError, logError } from './errors';
+import { AppError, handleError, logError } from './errors';
 import { APP_CONFIG } from './constants';
 
 // Generic API response type
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   data: T | null;
   error: AppError | null;
   loading: boolean;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -67,7 +67,7 @@ export const handleError = (error: unknown): AppError => {
 };
 
 // Error logging utility
-export const logError = (error: AppError, context?: Record<string, any>) => {
+export const logError = (error: AppError, context?: Record<string, unknown>) => {
   const errorInfo = {
     message: error.message,
     code: error.code,

--- a/src/lib/performance.ts
+++ b/src/lib/performance.ts
@@ -138,7 +138,7 @@ export const createIntersectionObserver = (
 // Memory usage monitoring
 export const getMemoryUsage = (): MemoryInfo | null => {
   if ('memory' in performance) {
-    return (performance as any).memory;
+    return (performance as Performance & { memory: MemoryInfo }).memory;
   }
   return null;
 };

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -9,20 +9,21 @@ export const sanitizeInput = (input: string): string => {
 };
 
 // Mask sensitive data for logging
-export const maskSensitiveData = (data: Record<string, any>): Record<string, any> => {
+export const maskSensitiveData = (data: Record<string, unknown>): Record<string, unknown> => {
   const sensitiveFields = ['password', 'token', 'key', 'secret', 'phone', 'email'];
-  const masked = { ...data };
-  
+  const masked: Record<string, unknown> = { ...data };
+
   Object.keys(masked).forEach(key => {
     if (sensitiveFields.some(field => key.toLowerCase().includes(field))) {
-      if (typeof masked[key] === 'string') {
-        masked[key] = masked[key].length > 4 
-          ? `${masked[key].slice(0, 2)}***${masked[key].slice(-2)}`
+      const value = masked[key];
+      if (typeof value === 'string') {
+        masked[key] = value.length > 4
+          ? `${value.slice(0, 2)}***${value.slice(-2)}`
           : '***';
       }
     }
   });
-  
+
   return masked;
 };
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -9,7 +9,7 @@ export const validateEmail = (email: string): boolean => {
 
 // Phone validation (basic international format)
 export const validatePhone = (phone: string): boolean => {
-  const phoneRegex = /^\+?[\d\s\-\(\)]{10,}$/;
+  const phoneRegex = /^\+?[\d\s\-()]{10,}$/;
   return phoneRegex.test(phone);
 };
 
@@ -84,7 +84,10 @@ export const validateCoordinates = (lat: number, lng: number): void => {
 };
 
 // Form validation helper
-export const validateForm = (data: Record<string, any>, rules: Record<string, (value: any) => void>): void => {
+export const validateForm = (
+  data: Record<string, unknown>,
+  rules: Record<string, (value: unknown) => void>
+): void => {
   const errors: string[] = [];
   
   Object.entries(rules).forEach(([field, validator]) => {


### PR DESCRIPTION
## Summary
- remove unused imports and replace `any` with `unknown`
- refine security helper to avoid `any`
- correct phone regex and memory usage typing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05d9b731c8329a808828925a37800