### PR TITLE
Fix landing page redirect loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { WrongApp } from './pages/WrongApp';
 import { RequestRide } from './pages/RequestRide';
 import { RideTracking } from './pages/RideTracking';
 import { History } from './pages/History';
+import { Landing } from './pages/Landing';
 import { validateEnvVars } from './lib/utils';
 import { APP_CONFIG } from './lib/constants';
 
@@ -59,11 +60,11 @@ function App() {
             </ProtectedRoute>
           } />
           
-          {/* Default redirect */}
-          <Route path="/" element={<Navigate to="/request" replace />} />
-          
+          {/* Landing page */}
+          <Route path="/" element={<Landing />} />
+
           {/* 404 fallback */}
-          <Route path="*" element={<Navigate to="/request" replace />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Router>
       

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+import { LoadingSpinner } from '../components/LoadingSpinner';
+
+export const Landing: React.FC = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-surface flex items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return <Navigate to={user ? '/request' : '/login'} replace />;
+};
+


### PR DESCRIPTION
## Summary
- Add landing page component that routes users to login or ride request based on auth state
- Use landing page for root and fallback routes to prevent redirect loops

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c07be20004832993d6cbd9c1d808b0