### PR TITLE
Guard Places Autocomplete until Maps loads

### DIFF
--- a/src/hooks/useGoogleMaps.ts
+++ b/src/hooks/useGoogleMaps.ts
@@ -82,25 +82,38 @@ export const useGoogleMaps = (elementId: string, config: MapConfig = {}): UseGoo
 };
 
 // Hook for Places Autocomplete
-export const usePlacesAutocomplete = (inputRef: React.RefObject<HTMLInputElement>) => {
-  const [autocomplete, setAutocomplete] = useState<google.maps.places.Autocomplete | null>(null);
+export const usePlacesAutocomplete = (
+  inputRef: React.RefObject<HTMLInputElement>,
+  isLoaded = false
+) => {
+  const [autocomplete, setAutocomplete] =
+    useState<google.maps.places.Autocomplete | null>(null);
   const [place, setPlace] = useState<google.maps.places.PlaceResult | null>(null);
 
   useEffect(() => {
-    if (inputRef.current && window.google) {
-      const autocompleteInstance = new google.maps.places.Autocomplete(inputRef.current, {
+    if (
+      !isLoaded ||
+      !inputRef.current ||
+      !window.google?.maps?.places?.Autocomplete
+    ) {
+      return;
+    }
+
+    const autocompleteInstance = new window.google.maps.places.Autocomplete(
+      inputRef.current,
+      {
         types: ['address'],
         componentRestrictions: { country: 'id' }, // Indonesia
-      });
+      }
+    );
 
-      autocompleteInstance.addListener('place_changed', () => {
-        const selectedPlace = autocompleteInstance.getPlace();
-        setPlace(selectedPlace);
-      });
+    autocompleteInstance.addListener('place_changed', () => {
+      const selectedPlace = autocompleteInstance.getPlace();
+      setPlace(selectedPlace);
+    });
 
-      setAutocomplete(autocompleteInstance);
-    }
-  }, [inputRef]);
+    setAutocomplete(autocompleteInstance);
+  }, [inputRef, isLoaded]);
 
   return { autocomplete, place, setPlace };
 };

--- a/src/pages/RequestRide.tsx
+++ b/src/pages/RequestRide.tsx
@@ -29,8 +29,8 @@ export const RequestRide: React.FC = () => {
     zoom: APP_CONFIG.map.defaultZoom,
   });
   
-  const { place: pickupPlace } = usePlacesAutocomplete(pickupRef);
-  const { place: dropoffPlace } = usePlacesAutocomplete(dropoffRef);
+  const { place: pickupPlace } = usePlacesAutocomplete(pickupRef, isLoaded);
+  const { place: dropoffPlace } = usePlacesAutocomplete(dropoffRef, isLoaded);
   
   // Debounce place changes to avoid excessive calculations
   const debouncedPickupPlace = useDebounce(pickupPlace, APP_CONFIG.ui.debounceDelay);


### PR DESCRIPTION
## Summary
- wait for Google Maps script before initializing Places Autocomplete
- wire RequestRide to pass map load state to the autocomplete hook

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c07e266cec8329ade401ad3de27d68