### PR TITLE
Simplify password validation error message

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -16,13 +16,9 @@ export const validatePhone = (phone: string): boolean => {
 // Password validation
 export const validatePassword = (password: string): { isValid: boolean; errors: string[] } => {
   const errors: string[] = [];
-  
+
   if (password.length < 6) {
     errors.push('Password must be at least 6 characters long');
-  }
-  
-  if (password.length > 0 && password.length < 6) {
-    errors.push('Password is too short');
   }
 
   return {


### PR DESCRIPTION
## Summary
- remove redundant short-password check to return a single error

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c095569eb08329a72b5852fa45ec6c