### PR TITLE
Import APP_CONFIG for map styling

### DIFF
--- a/src/hooks/useGoogleMaps.ts
+++ b/src/hooks/useGoogleMaps.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Loader } from '@googlemaps/js-api-loader';
+import { APP_CONFIG } from '../lib/constants';
 
 interface UseGoogleMapsReturn {
   isLoaded: boolean;


### PR DESCRIPTION
## Summary
- import APP_CONFIG in useGoogleMaps hook to apply configured map styles

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0955831e083298c7be36e71789c05