### PR TITLE
Use en-ZA locale for currency formatting

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,20 +1,6 @@
 // Format currency values
-export const formatCurrency = (amount: number, currency = 'IDR'): string => {
-  // For Indonesian Rupiah, show without decimals
-  if (currency === 'IDR') {
-    return new Intl.NumberFormat('id-ID', {
-      style: 'currency',
-      currency: 'IDR',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(amount * 15000); // Convert USD to IDR approximation
-  }
-  
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-  }).format(amount);
-};
+export const formatCurrency = (amount: number, currency = 'ZAR'): string =>
+  new Intl.NumberFormat('en-ZA', { style: 'currency', currency }).format(amount);
 
 // Format distance in km
 export const formatDistance = (distanceKm: number): string => {


### PR DESCRIPTION
## Summary
- simplify formatCurrency to Intl.NumberFormat('en-ZA')

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0a46e2e4c8329ac6691f2e7134fbe