### PR TITLE
Improve signup diagnostics and profile query

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -52,7 +52,7 @@ export const useAuth = (): AuthState => {
         .select(`
           id,
           role,
-          display_name,
+          full_name,
           phone,
           photo_url,
           email,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -113,7 +113,18 @@ export const Login: React.FC = () => {
         });
 
         if (error) {
-          toast.error(error.message);
+          console.error('Sign up error:', error);
+          const isDatabaseFailure =
+            error?.status === 500 ||
+            error.message?.toLowerCase().includes('database error saving new user');
+
+          if (isDatabaseFailure) {
+            toast.error(
+              'Sign up failed because the Supabase database rejected the request. Please run the database migration (supabase/migrations/create_schema.sql) in your project and try again.'
+            );
+          } else {
+            toast.error(error.message);
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary
- update the auth profile fetch to request the `full_name` column that exists in the Supabase schema
- add targeted handling for Supabase 500 signup responses so the UI prompts developers to run the SQL migration when the database rejects new users

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9718b3a5c8329b5f84f7e2236f407